### PR TITLE
SMP-1268: Remove cpu from resources.limits

### DIFF
--- a/src/redis/Chart.yaml
+++ b/src/redis/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/redis/values.yaml
+++ b/src/redis/values.yaml
@@ -13,7 +13,6 @@ useAntiAffinity: true
 redis:
   resources:
     limits:
-      cpu: 0.1
       memory: 200Mi
     requests:
       cpu: 0.1
@@ -29,7 +28,6 @@ redis:
 sentinel:
   resources:
     limits:
-      cpu: 100m
       memory: 200Mi
     requests:
       cpu: 100m


### PR DESCRIPTION
As per best practices, utilizing requests.cpu and removing limits.cpu

Refer: [SMP 1268: Remove CPU from the resource limits in Kubernetes Manifests](https://harness.atlassian.net/wiki/spaces/~7120205e3981db61bd4dcc8068ae7262d845f7/pages/edit-v2/21404484175)